### PR TITLE
downgrade manifest_version from 3 to 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Exclude all IDEA project files
 .idea/
+
+# Local build artifacts
+*.xpi
+web-ext-artifacts/

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Proton Calendar Toolbar Button",
   "description": "Adds a Proton Calendar button to the toolbar.",
   "version": "1.2",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "Proton Calendar Toolbar Button",
   "description": "Adds a Proton Calendar button to the toolbar.",
   "version": "1.2",

--- a/redirect.js
+++ b/redirect.js
@@ -1,5 +1,4 @@
-browser.spacesToolbar.addButton('ProtonCalendar', {
-    title: "Proton Calendar",
-    defaultIcons: "calendar-logo-greyscale.svg",
-    url: "https://calendar.proton.me"
+browser.spaces.create("ProtonCalendar", "https://calendar.proton.me", {
+  title: "Proton Calendar",
+  defaultIcons: "calendar-logo-greyscale.svg"
 });


### PR DESCRIPTION
Fix for issue #5 

The fix involves downgrading the manifest_version from 3 to 2. This is in line with the  manifest_version of the Thunderbird-ProtonMail-Addon.